### PR TITLE
Add a section explaining comments

### DIFF
--- a/lt-cljs-tutorial.cljs
+++ b/lt-cljs-tutorial.cljs
@@ -38,7 +38,7 @@
 ;; by preceding a line with a semi-colon, just like the lines you are reading
 ;; now.
 
-;; The second way is by proceding a form with `#_`. This causes ClojureScript
+;; The second way is by preceding a form with `#_`. This causes ClojureScript
 ;; to skip the evaluation of only the form immediately following, without
 ;; affecting the evaluation of the surrounding forms.
 


### PR DESCRIPTION
I added a section near the beginning to explain the three ways that
forms can be commented out. I also changed the non-compiling `deftype`
form to use the `comment` macro so that users could still try evaluating
the erroneous form if they want.
