### PR TITLE
defn functions inside let bindings are still available outside

### DIFF
--- a/lt-cljs-tutorial.cljs
+++ b/lt-cljs-tutorial.cljs
@@ -706,6 +706,9 @@ some-x
 
 ;; Above we defined `foo` and `bar` functions inside the scope of a
 ;; `let` form and they both know about `a` (i.e. they close over `a`)
+;; Even if defined inside a `let`, `foo` and `bar` are available
+;; in the outer scope.
+
 
 (foo)
 (bar)


### PR DESCRIPTION
I think this point is important, since in Javascript when you define a function inside a scope, this function is only available in this scope. Here ClojureScript allows a function defined in a `let` bindings (concept close to the `scope`) to be available outside the `let`. Not sure my change in the code nor this very comment is clear, but for a ClojureScript beginner like familiar with Javascript I felt this needed to be explained and explicit.
