### PR TITLE
Updating README to suggest using newer versions of Light Table 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 An introduction to the
 [ClojureScript](http://github.com/clojure/clojurescript) programming
-language aimed at [Light Table](http://www.lighttable.com) users.
+language aimed at [Light Table](http://www.lighttable.com) users. If you have
+an old version of Light Table, you may need to upgrade to 0.6.X or newer.
 
 Install [Leiningen](http://leiningen.org). You can then open
 `lt-cljs-tutorial.cljs` in Light Table and evaluate it interactively
@@ -17,3 +18,4 @@ as well.
 
 [1]: https://github.com/clojure/tools.nrepl
 [2]: https://github.com/magomimmo/modern-cljs/tree/master/cljs-tutorial
+


### PR DESCRIPTION
Related issue:

https://github.com/swannodette/lt-cljs-tutorial/issues/37
