### PR TITLE
Make equality on maps more readable

### DIFF
--- a/lt-cljs-tutorial.cljs
+++ b/lt-cljs-tutorial.cljs
@@ -474,11 +474,11 @@ a-list
 ;; ClojureScript has a much simpler notion of equality than what is present
 ;; in JavaScript. In ClojureScript equality is always deep equality.
 
-(= {:foo "bar" :baz "woz"} {:foo "bar" :baz "woz"})
+(= {:one 1 :two "2"} {:one 1 :two "2"})
 
 ;; Maps are not ordered.
 
-(= {:foo "bar" :baz "woz"} {:baz "woz" :foo "bar"})
+(= {:one 1 :two "2"} {:two "2" :one 1})
 
 ;; For sequential collections, equality just works.
 


### PR DESCRIPTION
- Easier to distinguish keys and values (letters x digits)
- Easier to see at glance that the order of switched, also helped by the keys
