### PR TITLE
Fix tiny typo.

### DIFF
--- a/lt-cljs-tutorial.cljs
+++ b/lt-cljs-tutorial.cljs
@@ -13,7 +13,7 @@
 ;; IMPORTANT: You must evaluate the very first form, the namespace
 ;; definition.
 
-;; Declaring a namespaces
+;; Declaring namespaces
 ;; ----------------------------------------------------------------------------
 
 ;; ClojureScript supports modularity via namespaces. They allow you to group


### PR DESCRIPTION
"Declaring a namespaces" ---> "Declaring namespaces"

This title is consistent with the other titles for example: 
"Comments"
"Definitions"
"Literal data types"
"Function literals"
